### PR TITLE
Feature/cross partition query support

### DIFF
--- a/Cosmy/CosmyClient.cs
+++ b/Cosmy/CosmyClient.cs
@@ -32,6 +32,15 @@ namespace Cosmy
             return query;
         }
 
+        public IQueryable<T> CreateDocumentQuery<T>(string collection, FeedOptions feedOptions)
+        {
+            var uri = UriFactory.CreateDocumentCollectionUri(configuration.Database, collection);
+
+            var query = this.documentClient.CreateDocumentQuery<T>(uri, feedOptions);
+
+            return query;
+        }
+
         public async Task<IEnumerable<T>> ExecuteQuery<T>(IQueryable<T> source) where T : class
         {
             return await source.ExecuteQuery();

--- a/Cosmy/CosmyClient.cs
+++ b/Cosmy/CosmyClient.cs
@@ -25,7 +25,7 @@ namespace Cosmy
         {
             var uri = UriFactory.CreateDocumentCollectionUri(configuration.Database, collection);
 
-            var partitionOptions = (partitionKey != null) ? new FeedOptions { PartitionKey = new PartitionKey(partitionKey) } : null;
+            var partitionOptions = (partitionKey != null) ? new FeedOptions { PartitionKey = new PartitionKey(partitionKey) } : new FeedOptions { EnableCrossPartitionQuery = true };
 
             var query = this.documentClient.CreateDocumentQuery<T>(uri, partitionOptions);
 

--- a/Cosmy/ICosmyClient.cs
+++ b/Cosmy/ICosmyClient.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Microsoft.Azure.Documents.Client;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -8,6 +9,7 @@ namespace Cosmy
     public interface ICosmyClient
     {
         IQueryable<T> CreateDocumentQuery<T>(string collection, object partitionKey = null);
+        IQueryable<T> CreateDocumentQuery<T>(string collection, FeedOptions feedOptions);
         Task DeleteDocumentAsync(Guid documentId, string collection, object partitionKey = null);
         Task DeleteDocumentAsync(string documentId, string collection, object partitionKey = null);
         Task<IEnumerable<TResult>> ExecuteQuery<T, TResult>(IQueryable<T> source) where T : class;


### PR DESCRIPTION
## Description

- Fixed exception thrown when calling _CreateDocumentQuery<T>(string collection, object partitionKey = null)_ without specifying partition key.

- Added an overload to the existing CreateDocumentQuery<T> method with FeedOptions as a required parameter. _CreateDocumentQuery<T>(string collection, FeedOptions feedOptions)_. 
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

- [x]  New feature (non-breaking change which adds functionality)

- [x]  Breaking change (fix or feature that would cause existing functionality to not work as expected)

- [x] This change requires a documentation update

## Closing issues
#1
